### PR TITLE
Specify max size to baseUrl in downloading photos

### DIFF
--- a/pinatra.rb
+++ b/pinatra.rb
@@ -86,7 +86,7 @@ get "/:album_id/photos" do
 # public/photo以下に<photo_id>.jpgとして保存
   photos.each do |p|
     unless File.exist?("public/photo/#{p["id"]}.jpg")
-      open(p["baseUrl"]) do |file|
+      open("#{p[`baseUrl`]=w1024-h1024}") do |file|
         filename = "#{p["id"]}.jpg"
         open("public/photo/#{filename}", "w+b") do |out|
           out.write(file.read)
@@ -118,7 +118,7 @@ get "/:album_id/photos" do
     content = json
   end
 
- 
+
 
   # FIXME: アルバムに更新がなければ保存したキャッシュを使うほうがよい．
   #cache.save(album_id, json)


### PR DESCRIPTION
### やったこと
これまでは，baseUrlを用いて写真を取得する際，サイズの指定を指定なかった．
しかし，公式のドキュメントを見ると，baseUrlを用いる際は，サイズの指定をすべきだという記述があった．
https://developers.google.com/photos/library/reference/rest/v1/mediaItems
このため，サイズの指定を行なった．(縦，横最大1024px)