### PR TITLE
Modify to cache only necessary photo

### DIFF
--- a/googlephoto_client.rb
+++ b/googlephoto_client.rb
@@ -93,5 +93,27 @@ module Pinatra
         retry
       end
     end
+
+# mediaItemsID で指定された画像を get
+    def get_photo(mediaitem_id)
+      url = "https://photoslibrary.googleapis.com/v1/mediaItems/#{mediaitem_id}"
+      uri = URI.parse(url)
+      header =  { "Authorization" => "Bearer #{@credentials.access_token}", "Content-Type" => "application/json" }
+      begin
+        res = Net::HTTP.start(uri.host, uri.port, use_ssl: true) do |http|
+          http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+          http.get(uri.request_uri, header)
+        end
+        if res.class == Net::HTTPOK
+          return JSON.parse(res.body)
+        else
+          raise "HTTPRequestFailed"
+        end
+      rescue
+        @credentials.refresh!
+        header["Authorization"] = "Bearer #{@credentials.access_token}"
+        retry
+      end
+    end
   end
 end # module Pinatra

--- a/pinatra.rb
+++ b/pinatra.rb
@@ -72,14 +72,13 @@ get "/hello" do
   "Suzuki Shinra!!"
 end
 
-get "/photo/:photo_id" do
+get /\/photo\/(.*).jpg/ do
   CONFIG_PATH = "#{ENV['HOME']}/.config/pinatra/config.yml"
   config = YAML.load_file(CONFIG_PATH)
 
-  params[:photo_id].gsub!(/\.jpg$/, "")
-  photo_url = "photo/#{params[:photo_id]}.jpg"
+  photo_url = "photo/#{params['captures'].first}.jpg"
   if !File.exist?(photo_url)
-    photo = google_photo_client.get_photo(params[:photo_id]).to_h
+    photo = google_photo_client.get_photo(params['captures'].first).to_h
     open("#{photo['baseUrl']}=w1024-h1024") do |file|
       open(photo_url, "w+b") do |output|
         output.write(file.read)
@@ -117,7 +116,7 @@ get "/:album_id/photos" do
 
   photos.each do |p|
     photo = {
-      src: "#{config["host_url"]}/photo/#{p["id"]}",
+      src: "#{config["host_url"]}/photo/#{p["id"].jpg}",
       title: p["filename"],
       id: p["id"],
       thumb: {

--- a/pinatra.rb
+++ b/pinatra.rb
@@ -72,7 +72,7 @@ get "/hello" do
   "Suzuki Shinra!!"
 end
 
-get /\/photo\/(.*).jpg/ do
+get /\/photo\/(.*)\.jpg$/ do
   CONFIG_PATH = "#{ENV['HOME']}/.config/pinatra/config.yml"
   config = YAML.load_file(CONFIG_PATH)
 

--- a/pinatra.rb
+++ b/pinatra.rb
@@ -116,7 +116,7 @@ get "/:album_id/photos" do
 
   photos.each do |p|
     photo = {
-      src: "#{config["host_url"]}/photo/#{p["id"].jpg}",
+      src: "#{config["host_url"]}/photo/#{p["id"]}.jpg",
       title: p["filename"],
       id: p["id"],
       thumb: {

--- a/pinatra.rb
+++ b/pinatra.rb
@@ -72,6 +72,25 @@ get "/hello" do
   "Suzuki Shinra!!"
 end
 
+get "/photo/:photo_id" do
+  CONFIG_PATH = "#{ENV['HOME']}/.config/pinatra/config.yml"
+  config = YAML.load_file(CONFIG_PATH)
+
+  photo_url = "/photo/#{params[:photo_id]}.jpg"
+  if !File.exist?(photo_url)
+    photo = google_photo_client.get_photo(params[:photo_id]).to_h
+    open("#{photo['baseUrl']}=w1024-h1024") do |file|
+      open(photo_url, "w+b") do |output|
+        output.write(file.read)
+      end
+    end
+  end
+
+  open(photo_url, "r") do |file|
+    file.read
+  end
+end
+
 get "/:album_id/photos" do
   CONFIG_PATH = "#{ENV['HOME']}/.config/pinatra/config.yml"
   config = YAML.load_file(CONFIG_PATH)
@@ -82,22 +101,22 @@ get "/:album_id/photos" do
 
   photos = google_photo_client.get_albumphotos(album_id).to_h["mediaItems"]
 
-# アルバムを取得後，各写真を保存する
-# public/photo以下に<photo_id>.jpgとして保存
-  photos.each do |p|
-    unless File.exist?("public/photo/#{p["id"]}.jpg")
-      open("#{p['baseUrl']}=w1024-h1024") do |file|
-        filename = "#{p["id"]}.jpg"
-        open("public/photo/#{filename}", "w+b") do |out|
-          out.write(file.read)
-        end
-      end
-    end
-  end
+  # アルバムを取得後，各写真を保存する
+  # public/photo以下に<photo_id>.jpgとして保存
+  # photos.each do |p|
+  #   unless File.exist?("public/photo/#{p["id"]}.jpg")
+  #     open("#{p['baseUrl']}=w1024-h1024") do |file|
+  #       filename = "#{p["id"]}.jpg"
+  #       open("public/photo/#{filename}", "w+b") do |out|
+  #         out.write(file.read)
+  #       end
+  #     end
+  #   end
+  # end
 
   photos.each do |p|
     photo = {
-      src: "#{config["host_url"]}/photo/#{p["id"]}.jpg",
+      src: "#{config["host_url"]}/photo/#{p["id"]}",
       title: p["filename"],
       id: p["id"],
       thumb: {

--- a/pinatra.rb
+++ b/pinatra.rb
@@ -72,7 +72,9 @@ get "/hello" do
   "Suzuki Shinra!!"
 end
 
-get /\/photo\/(.*)\.jpg$/ do
+# 注意: sinatraが用いている正規表現ライブラリでは，終端表現が使えない
+# https://github.com/sinatra/mustermann
+get /\/photo\/(.*)\.jpg/ do
   CONFIG_PATH = "#{ENV['HOME']}/.config/pinatra/config.yml"
   config = YAML.load_file(CONFIG_PATH)
 

--- a/pinatra.rb
+++ b/pinatra.rb
@@ -76,7 +76,7 @@ get "/photo/:photo_id" do
   CONFIG_PATH = "#{ENV['HOME']}/.config/pinatra/config.yml"
   config = YAML.load_file(CONFIG_PATH)
 
-  photo_url = "/photo/#{params[:photo_id]}.jpg"
+  photo_url = "photo/#{params[:photo_id]}.jpg"
   if !File.exist?(photo_url)
     photo = google_photo_client.get_photo(params[:photo_id]).to_h
     open("#{photo['baseUrl']}=w1024-h1024") do |file|

--- a/pinatra.rb
+++ b/pinatra.rb
@@ -76,6 +76,7 @@ get "/photo/:photo_id" do
   CONFIG_PATH = "#{ENV['HOME']}/.config/pinatra/config.yml"
   config = YAML.load_file(CONFIG_PATH)
 
+  params[:photo_id].gsub!(/\.jpg$/, "")
   photo_url = "photo/#{params[:photo_id]}.jpg"
   if !File.exist?(photo_url)
     photo = google_photo_client.get_photo(params[:photo_id]).to_h


### PR DESCRIPTION
#16 に対するPRである．

### はじめに
+ これまで，piantraはGoogle photo のnomnichi アルバムの写真をすべて取得し，すべてpintatra/public/photoに保存していた．
+ 上記方法だと非効率であるため，URLが要求された時にGoogle photoから写真を取得するようにした．
+ また，以前は，写真データをそのまま公開していた．しかし，本PRにて，写真そのものの公開をやめ，一度pinatraがリクエストを受け，その後，写真データを返却するようにした．

### やったこと
+ googlephoto_client.rbに，get_photoメソッドを追加
  + アルバムの取得ではなく，単一の写真を取得するメソッドを追加した．実は過去のコミット(a6ee97e)でrevertした処理
  + photo_idを引数とし，Google Photo APIのmediaitems.getのリクエスト(json形式)を返す
     + 参考: https://developers.google.com/photos/library/reference/rest/v1/mediaItems/get

+ pinatra.rb に，新しいurl( get "/photo/:photo_id")を追加した
  + "photo/photo_id.jpg" が存在しない場合，get_photoメソッドを用いて写真データを取得し，ファイルとして保存する．その後，写真データを返却する．
  + 以前は，写真そのものを公開し，そのurlを返却していたが，一度pinatraが仲介するようにした