### PR TITLE
Modify to read album_id from config.yml and Fix bug about loop

### DIFF
--- a/config.yml.sample
+++ b/config.yml.sample
@@ -3,3 +3,6 @@ client_secret: ***************************
 token_store: /Users/<username>/.config/pinatra/token_store.yml
 default_user: ***************************
 host_url: *************************
+album_id:
+  - *************************
+  - *************************

--- a/googlephoto_client.rb
+++ b/googlephoto_client.rb
@@ -85,7 +85,7 @@ module Pinatra
         if res.class == Net::HTTPOK
           return JSON.parse(res.body)
         else
-          raise "HTTPRequestFailed"
+          return nil
         end
       rescue
         @credentials.refresh!

--- a/pinatra.rb
+++ b/pinatra.rb
@@ -104,15 +104,20 @@ get /\/photo\/(.*)\.jpg/ do
   end
 end
 
-get "/:album_id/photos" do
+get "/photos" do
   CONFIG_PATH = "#{ENV['HOME']}/.config/pinatra/config.yml"
   config = YAML.load_file(CONFIG_PATH)
 
+  photos = []
   contents = []
   callback = params['callback']
-  album_id = params[:album_id]
+  album_id_list = config["album_id"]
 
-  photos = google_photo_client.get_albumphotos(album_id).to_h["mediaItems"]
+  album_id_list.each do |album_id|
+    photos = Array(photos) << google_photo_client.get_albumphotos(album_id).to_h["mediaItems"]
+  end
+  photos.flatten!
+  photos.compact!
 
   # アルバムを取得後，各写真を保存する
   # public/photo以下に<photo_id>.jpgとして保存
@@ -191,7 +196,7 @@ post "/:album_id/photo/new" do
     contents << hash
     title = nil unless title == nil
   end
-
+  
   json = contents.to_json
   content_type :json
 


### PR DESCRIPTION
### 363ca53 について
#19 に対する PR である．
複数のアルバムidを設定するために，`config.yml.sample` に以下の行を追記した．
```
album_id:
  - *************************
  - *************************
```
それに伴い，`config.yml` から複数のアルバムidを読み込むように`pinatra.rb` を変更した．

### acacf30 について
`googlephoto_client.rb` の get_albumphotos 関数内で，リクエストが失敗したとき，例外処理が発生する．このとき，rescue 処理として retry を行い，再度例外処理が発生するため，ループする．リクエストが失敗したときに，例外処理ではなく nil を返すことで，これに対処した．