### PR TITLE
Set content type(jpeg) in get photo url

### DIFF
--- a/pinatra.rb
+++ b/pinatra.rb
@@ -99,6 +99,8 @@ get /\/photo\/(.*)\.jpg/ do
     end
   end
 
+  content_type :jpeg
+
   open(photo_url, "r") do |file|
     file.read
   end
@@ -196,7 +198,7 @@ post "/:album_id/photo/new" do
     contents << hash
     title = nil unless title == nil
   end
-  
+
   json = contents.to_json
   content_type :json
 


### PR DESCRIPTION
#25 に対するPRである．

### やったこと
+ 画像を表示する際に，`Content-Type`が`image/jpeg`になるようにした．
+ sinatraの記述方法で，
```
content_type :jpeg
```
と記述すると，レスポンスの`Content-Type`を記述できるようになる．

+ 参考サイト
  + http://sinatrarb.com/intro-ja.html
  + https://rightgo09-ruby.hatenadiary.org/entry/20130828/p1

### 今後の課題
+ 現状は，画像データがjpegであるという前提でurlを設計し，`Content-Type`をjpegにしている．
+ 本来は，png画像の際は，`Content-Type`がpngになるようにしたほうがよい．
+ これについて，png画像を，`Content-Type` jpegとしても，ブラウザから画像を確認できた．よって，実用上は問題ない．